### PR TITLE
Add multiple shacl files to the API

### DIFF
--- a/tests/e2e/test_entrypoints_api_handlers.py
+++ b/tests/e2e/test_entrypoints_api_handlers.py
@@ -25,7 +25,31 @@ def test_validate_file_success_different_file_types(mock_build_report_from_file,
 
     data = {
         'data_file': FileStorage(BytesIO(b'data file content'), filename),
-        'schema_file': FileStorage(BytesIO(b''), 'schema_' + filename)
+        'schema_file0': FileStorage(BytesIO(b''), 'schema_' + filename)
+    }
+
+    mock_build_report_from_file.return_value = str(report), 'report.ttl'
+
+    response = api_client.post('/validate-file', data=data, content_type='multipart/form-data')
+
+    assert response.status_code == 200
+    assert 'text/turtle' in response.content_type
+    assert 'validation success' in response.data.decode()
+
+
+@patch('validator.entrypoints.api.handlers.build_report_from_file')
+def test_validate_file_success_multiple_shacl_files_success(mock_build_report_from_file,
+                                                            api_client, tmpdir):
+    report = tmpdir.join('report.ttl')
+    report.write('validation success')
+
+    data = {
+        'data_file': FileStorage(BytesIO(b'data file content'), 'data.ttl'),
+        'schema_file0': FileStorage(BytesIO(b''), 'schema_' + 'shacl0.ttl'),
+        'schema_file1': FileStorage(BytesIO(b''), 'schema_' + 'shacl1.ttl'),
+        'schema_file2': FileStorage(BytesIO(b''), 'schema_' + 'shacl2.ttl'),
+        'schema_file3': FileStorage(BytesIO(b''), 'schema_' + 'shacl3.ttl'),
+        'schema_file4': FileStorage(BytesIO(b''), 'schema_' + 'shacl4.ttl'),
     }
 
     mock_build_report_from_file.return_value = str(report), 'report.ttl'
@@ -41,7 +65,7 @@ def test_validate_file_type_exception_one(api_client):
     unacceptable_filename = 'schema_file.pdf'
     data = {
         'data_file': FileStorage(BytesIO(b''), 'data_file.rdf'),
-        'schema_file': FileStorage(BytesIO(b''), unacceptable_filename)
+        'schema_file0': FileStorage(BytesIO(b''), unacceptable_filename)
     }
     response = api_client.post('/validate-file', data=data, content_type='multipart/form-data')
 
@@ -55,7 +79,7 @@ def test_validate_file_type_exception_two(api_client):
 
     data = {
         'data_file': FileStorage(BytesIO(b''), unacceptable_filename_1),
-        'schema_file': FileStorage(BytesIO(b''), unacceptable_filename_2)
+        'schema_file0': FileStorage(BytesIO(b''), unacceptable_filename_2)
     }
 
     response = api_client.post('/validate-file', data=data, content_type='multipart/form-data')
@@ -75,7 +99,7 @@ def test_validate_file_success_different_report_extensions(mock_build_report_fro
 
     data = {
         'data_file': FileStorage(BytesIO(b'data file content'), 'data.ttl'),
-        'schema_file': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl')
+        'schema_file0': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl')
     }
 
     mock_build_report_from_file.return_value = str(report), f'report.{report_extension}'
@@ -91,7 +115,7 @@ def test_validate_file_success_different_report_extensions(mock_build_report_fro
 def test_validate_file_fail_report_extension(api_client):
     data = {
         'data_file': FileStorage(BytesIO(b'data file content'), 'data.ttl'),
-        'schema_file': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl')
+        'schema_file0': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl')
     }
 
     invalid_extension = 'pdf'
@@ -111,7 +135,32 @@ def test_validate_sparql_endpoint_success(mock_build_report_from_sparql_endpoint
     report.write('validation success')
 
     data = {
-        'schema_file': FileStorage(BytesIO(b'shape file content'), filename),
+        'schema_file0': FileStorage(BytesIO(b'shape file content'), filename),
+        'graphs': ['shape1', 'shape2'],
+        'sparql_endpoint_url': 'http://sparql.endpoint'
+    }
+
+    mock_build_report_from_sparql_endpoint.return_value = str(report), 'report.ttl'
+
+    response = api_client.post('/validate-sparql-endpoint', data=data, content_type='multipart/form-data')
+
+    assert response.status_code == 200
+    assert 'text/turtle' in response.content_type
+    assert 'validation success' in response.data.decode()
+
+
+@patch('validator.entrypoints.api.handlers.build_report_from_sparql_endpoint')
+def test_validate_sparql_endpoint_multiple_shacl_files_success(mock_build_report_from_sparql_endpoint,
+                                                               api_client, tmpdir):
+    report = tmpdir.join('report.ttl')
+    report.write('validation success')
+
+    data = {
+        'schema_file0': FileStorage(BytesIO(b''), 'schema_' + 'shacl0.ttl'),
+        'schema_file1': FileStorage(BytesIO(b''), 'schema_' + 'shacl1.ttl'),
+        'schema_file2': FileStorage(BytesIO(b''), 'schema_' + 'shacl2.ttl'),
+        'schema_file3': FileStorage(BytesIO(b''), 'schema_' + 'shacl3.ttl'),
+        'schema_file4': FileStorage(BytesIO(b''), 'schema_' + 'shacl4.ttl'),
         'graphs': ['shape1', 'shape2'],
         'sparql_endpoint_url': 'http://sparql.endpoint'
     }
@@ -128,7 +177,7 @@ def test_validate_sparql_endpoint_success(mock_build_report_from_sparql_endpoint
 def test_validate_sparql_endpoint_type_exception_one(api_client):
     unacceptable_filename = 'schema_file.pdf'
     data = {
-        'schema_file': FileStorage(BytesIO(b''), unacceptable_filename),
+        'schema_file0': FileStorage(BytesIO(b''), unacceptable_filename),
         'graphs': ['shape1', 'shape2'],
         'sparql_endpoint_url': 'http://sparql.endpoint'
     }
@@ -140,7 +189,7 @@ def test_validate_sparql_endpoint_type_exception_one(api_client):
 
 def test_validate_sparql_endpoint_fail_report_extension(api_client):
     data = {
-        'schema_file': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl'),
+        'schema_file0': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl'),
         'graphs': ['shape1', 'shape2'],
         'sparql_endpoint_url': 'http://sparql.endpoint'
     }
@@ -156,14 +205,15 @@ def test_validate_sparql_endpoint_fail_report_extension(api_client):
 @pytest.mark.parametrize("report_extension, content_type",
                          [('ttl', 'text/turtle'), ('html', 'text/html'), ('zip', 'application/zip')])
 @patch('validator.entrypoints.api.handlers.build_report_from_sparql_endpoint')
-def test_validate_file_success_different_report_extensions(build_report_from_sparql_endpoint, report_extension,
-                                                           content_type,
-                                                           api_client, tmpdir):
+def test_validate_sparql_endpoint_success_different_report_extensions(build_report_from_sparql_endpoint,
+                                                                      report_extension,
+                                                                      content_type,
+                                                                      api_client, tmpdir):
     report = tmpdir.join(f'report.{report_extension}')
     report.write('validation success')
 
     data = {
-        'schema_file': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl'),
+        'schema_file0': FileStorage(BytesIO(b'shacl file content'), 'shacl.ttl'),
         'graphs': ['shape1', 'shape2'],
         'sparql_endpoint_url': 'http://sparql.endpoint'
     }
@@ -181,7 +231,7 @@ def test_validate_file_success_different_report_extensions(build_report_from_spa
 def test_validate_sparql_endpoint_schema_file_type_exception(api_client):
     unacceptable_filename = 'schema_file.pdf'
     data = {
-        'schema_file': FileStorage(BytesIO(b'data file content'), unacceptable_filename),
+        'schema_file0': FileStorage(BytesIO(b'data file content'), unacceptable_filename),
         'graphs': ['shape1', 'shape2'],
         'sparql_endpoint_url': 'http://sparql.endpoint'
     }

--- a/tests/e2e/test_entrypoints_api_handlers.py
+++ b/tests/e2e/test_entrypoints_api_handlers.py
@@ -226,18 +226,3 @@ def test_validate_sparql_endpoint_success_different_report_extensions(build_repo
     assert response.status_code == 200
     assert content_type in response.content_type
     assert 'validation success' in response.data.decode()
-
-
-def test_validate_sparql_endpoint_fail_report_extension(api_client):
-    data = {
-        'schema_file0': FileStorage(BytesIO(b'data file content'), unacceptable_filename),
-        'graphs': ['shape1', 'shape2'],
-        'sparql_endpoint_url': 'http://sparql.endpoint'
-    }
-
-    invalid_extension = 'pdf'
-
-    response = api_client.post(f'/validate-sparql-endpoint?report_extension={invalid_extension}', data=data,
-                               content_type='multipart/form-data')
-    assert response.status_code == 422
-    assert 'Wrong report_extension format. Accepted formats: ttl, html, zip' in response.json.get('detail')

--- a/validator/entrypoints/api/handlers.py
+++ b/validator/entrypoints/api/handlers.py
@@ -23,20 +23,27 @@ from validator.service_layer.handlers import build_report_from_file, build_repor
 logger = logging.getLogger(__name__)
 
 
-def validate_file(data_file: FileStorage, schema_file: FileStorage,
+def validate_file(data_file: FileStorage,
+                  schema_file0: FileStorage, schema_file1: FileStorage = None, schema_file2: FileStorage = None,
+                  schema_file3: FileStorage = None, schema_file4: FileStorage = None,
                   report_extension: str = DEFAULT_REPORT_EXTENSION) -> tuple:
     """
     API method to handle file validation.
     :param data_file: The file to be validated
-    :param schema_file: The content of the SHACL shape files defining the validation constraints
+    :param schema_file0 - schema_file4: The content of the SHACL shape files defining the validation constraints
     :param report_extension: type of file to be returned. Can be `html`, `ttl`, or `zip`. Defaults to `ttl`
     :return: the validation report in the requested format
     :rtype: report file (html, ttl or zip format), int
     """
+    schema_files = list()
+    for schema_file in [schema_file0, schema_file1, schema_file2, schema_file3, schema_file4]:
+        if schema_file:
+            schema_files.append(schema_file)
+
     file_exceptions = list()
-    for file in [data_file.filename, schema_file.filename]:
-        if not _guess_file_type(file):
-            file_exceptions.append(file)
+    for file in [data_file, *schema_files]:
+        if not _guess_file_type(file.filename):
+            file_exceptions.append(file.filename)
     if file_exceptions:
         exception_text = 'File type errors: ' + ', '.join(file_exceptions) + '. Acceptable types: ' + \
                          ', '.join([f'{key}({value})' for (key, value) in INPUT_MIME_TYPES.items()]) + '.'
@@ -52,13 +59,15 @@ def validate_file(data_file: FileStorage, schema_file: FileStorage,
             local_data_file = Path(temp_folder) / str(data_file.filename)
             data_file.save(local_data_file)
 
-            local_schema_file = Path(temp_folder) / str(schema_file.filename)
-            schema_file.save(local_schema_file)
+            local_schema_files = list()
+            for schema_file in schema_files:
+                local_schema_file = Path(temp_folder) / str(schema_file.filename)
+                schema_file.save(local_schema_file)
+                local_schema_files.append(str(local_schema_file))
 
-            print('from handler', report_extension)
             report_path, report_filename = build_report_from_file(temp_folder,
                                                                   str(local_data_file),
-                                                                  str(local_schema_file),
+                                                                  local_schema_files,
                                                                   report_extension, data_file.filename)
 
             return send_file(report_path, as_attachment=True, attachment_filename=report_filename)  # 200
@@ -67,22 +76,35 @@ def validate_file(data_file: FileStorage, schema_file: FileStorage,
         raise InternalServerError(str(e))
 
 
-def validate_sparql_endpoint(body, schema_file: FileStorage, report_extension: str = DEFAULT_REPORT_EXTENSION) -> tuple:
+def validate_sparql_endpoint(body,
+                             schema_file0: FileStorage, schema_file1: FileStorage = None,
+                             schema_file2: FileStorage = None, schema_file3: FileStorage = None,
+                             schema_file4: FileStorage = None,
+                             report_extension: str = DEFAULT_REPORT_EXTENSION) -> tuple:
     """
   
     :param body: a dictionary with the json fields:
         :sparql_endpoint_url - The endpoint to validate
         :graphs - An optional list of named graphs to restrict the scope of the validation
-    :param schema_file: The content of the SHACL shape files defining the validation constraints
+    :param schema_file0 - schema_file4: The content of the SHACL shape files defining the validation constraints
     :param report_extension: type of file to be returned. Can be `html`, `ttl`, or `zip`. Defaults to `ttl`
     :return: the validation ttl file
     :rtype: ttl file, int
     """
+    schema_files = list()
+    for schema_file in [schema_file0, schema_file1, schema_file2, schema_file3, schema_file4]:
+        if schema_file:
+            schema_files.append(schema_file)
+
     sparql_endpoint_url = body.get('sparql_endpoint_url')
     graphs = body.get('graphs')
 
-    if not _guess_file_type(schema_file.filename):
-        exception_text = 'File type errors: ' + schema_file.filename + '. Acceptable types: ' + \
+    file_exceptions = list()
+    for file in schema_files:
+        if not _guess_file_type(file.filename):
+            file_exceptions.append(file.filename)
+    if file_exceptions:
+        exception_text = 'File type errors: ' + ', '.join(file_exceptions) + '. Acceptable types: ' + \
                          ', '.join([f'{key}({value})' for (key, value) in INPUT_MIME_TYPES.items()]) + '.'
         raise UnsupportedMediaType(exception_text)
 
@@ -93,13 +115,16 @@ def validate_sparql_endpoint(body, schema_file: FileStorage, report_extension: s
 
     try:
         with tempfile.TemporaryDirectory() as temp_folder:
-            local_schema_file = Path(temp_folder) / str(schema_file.filename)
-            schema_file.save(local_schema_file)
+            local_schema_files = list()
+            for schema_file in schema_files:
+                local_schema_file = Path(temp_folder) / str(schema_file.filename)
+                schema_file.save(local_schema_file)
+                local_schema_files.append(str(local_schema_file))
 
             report_path, report_filename = build_report_from_sparql_endpoint(temp_folder,
                                                                              sparql_endpoint_url,
                                                                              graphs,
-                                                                             str(local_schema_file),
+                                                                             local_schema_files,
                                                                              report_extension,
                                                                              'filename')
 

--- a/validator/entrypoints/api/openapi/openapi.yaml
+++ b/validator/entrypoints/api/openapi/openapi.yaml
@@ -35,35 +35,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              type: object
-              properties:
-                data_file:
-                  type: string
-                  format: binary
-                  description: The data content to validate
-                schema_file0:
-                  type: string
-                  format: binary
-                  description: The content of the SHACL shape file defining the validation constraints
-                schema_file1:
-                  type: string
-                  format: binary
-                  description: The content of the SHACL shape file defining the validation constraints
-                schema_file2:
-                  type: string
-                  format: binary
-                  description: The content of the SHACL shape file defining the validation constraints
-                schema_file3:
-                  type: string
-                  format: binary
-                  description: The content of the SHACL shape file defining the validation constraints
-                schema_file4:
-                  type: string
-                  format: binary
-                  description: The content of the SHACL shape file defining the validation constraints
-              required:
-                - data_file
-                - schema_file0
+              $ref: '#/components/schemas/FileValidator'
       responses:
         200:
           description: Request to validate endpoint successfully accepted for processing.
@@ -85,14 +57,6 @@ paths:
             schema:
               type: object
               properties:
-                sparql_endpoint_url:
-                  type: string
-                  description: The endpoint to validate
-                graphs:
-                  type: array
-                  description: An optional list of named graphs to restrict the scope of the validation
-                  items:
-                    type: string
                 schema_file0:
                   type: string
                   format: binary
@@ -113,11 +77,60 @@ paths:
                   type: string
                   format: binary
                   description: The content of the SHACL shape file defining the validation constraints
+                graphs:
+                  type: array
+                  description: An optional list of named graphs to restrict the scope of the validation
+                  items:
+                    type: string
+                sparql_endpoint_url:
+                  type: string
+                  description: The endpoint to validate
               required:
-                - sparql_endpoint_url
                 - schema_file0
+                - sparql_endpoint_url
       responses:
         200:
           description: Request to validate endpoint successfully accepted for processing.
         5XX:
           description: Unexpected Error.
+
+components:
+  schemas:
+    GenericValidator:
+      type: object
+      description: Base "class" for defining validator api structure
+      properties:
+        schema_file0:
+          type: string
+          format: binary
+          description: The content of the SHACL shape file defining the validation constraints
+        schema_file1:
+          type: string
+          format: binary
+          description: The content of the SHACL shape file defining the validation constraints
+        schema_file2:
+          type: string
+          format: binary
+          description: The content of the SHACL shape file defining the validation constraints
+        schema_file3:
+          type: string
+          format: binary
+          description: The content of the SHACL shape file defining the validation constraints
+        schema_file4:
+          type: string
+          format: binary
+          description: The content of the SHACL shape file defining the validation constraints
+    FileValidator:
+      type: object
+      description: File validator
+      allOf:
+        - $ref: '#/components/schemas/GenericValidator'
+        - type: object
+          properties:
+            data_file:
+              type: string
+              format: binary
+              description: The data content to validate
+          required:
+            - schema_file0
+            - data_file

--- a/validator/entrypoints/api/openapi/openapi.yaml
+++ b/validator/entrypoints/api/openapi/openapi.yaml
@@ -41,13 +41,29 @@ paths:
                   type: string
                   format: binary
                   description: The data content to validate
-                schema_file:
+                schema_file0:
                   type: string
                   format: binary
-                  description: The content of the SHACL shape files defining the validation constraints
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file1:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file2:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file3:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file4:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
               required:
                 - data_file
-                - schema_file
+                - schema_file0
       responses:
         200:
           description: Request to validate endpoint successfully accepted for processing.
@@ -77,13 +93,29 @@ paths:
                   description: An optional list of named graphs to restrict the scope of the validation
                   items:
                     type: string
-                schema_file:
+                schema_file0:
                   type: string
                   format: binary
-                  description: The content of the SHACL shape files defining the validation constraints
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file1:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file2:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file3:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
+                schema_file4:
+                  type: string
+                  format: binary
+                  description: The content of the SHACL shape file defining the validation constraints
               required:
                 - sparql_endpoint_url
-                - schema_file
+                - schema_file0
       responses:
         200:
           description: Request to validate endpoint successfully accepted for processing.

--- a/validator/entrypoints/ui/api_wrapper.py
+++ b/validator/entrypoints/ui/api_wrapper.py
@@ -8,37 +8,40 @@
 """
 Service to consume validator API.
 """
+from typing import List
+
 import requests
 from werkzeug.datastructures import FileStorage
 
 from validator.entrypoints.ui import config
 
 
-def validate_file(data_file: FileStorage, schema_file: FileStorage, report_extension: str) -> tuple:
+def validate_file(data_file: FileStorage, schema_files: List[FileStorage], report_extension: str) -> tuple:
     """
     Method to connect to the validator api to validate a file.
     :param data_file: The file to be validated
-    :param schema_file: The content of the SHACL shape files defining the validation constraints
+    :param schema_files: The content of the SHACL shape files defining the validation constraints
     :param report_extension:
     :return: state of the api response
     :rtype: file, int
     """
     files = {
         'data_file': (data_file.filename, data_file.stream, data_file.mimetype),
-        'schema_file': (schema_file.filename, schema_file.stream, schema_file.mimetype)
     }
+    for index, schema_file in enumerate(schema_files):
+        files[f'schema_file{index}'] = (schema_file.filename, schema_file.stream, schema_file.mimetype)
 
     response = requests.post(config.VALIDATOR_API_ENDPOINT + '/validate-file', files=files,
                              params={'report_extension': report_extension})
     return response.content, response.status_code
 
 
-def validate_sparql_endpoint(sparql_endpoint_url: str, schema_file: FileStorage, report_extension: str,
+def validate_sparql_endpoint(sparql_endpoint_url: str, schema_files: List[FileStorage], report_extension: str,
                              graphs: list = None):
     """
     Method to connect to the validator api to validate a SPARQL endpoint.
     :param sparql_endpoint_url: The endpoint to validate
-    :param schema_file: The content of the SHACL shape files defining the validation constraints
+    :param schema_files: The content of the SHACL shape files defining the validation constraints
     :param report_extension:
     :param graphs: An optional list of named graphs to restrict the scope of the validation
     :return:
@@ -50,9 +53,9 @@ def validate_sparql_endpoint(sparql_endpoint_url: str, schema_file: FileStorage,
     if graphs:
         data['graphs'] = graphs
 
-    files = {
-        'schema_file': (schema_file.filename, schema_file.stream, schema_file.mimetype)
-    }
+    files = dict()
+    for index, schema_file in enumerate(schema_files):
+        files[f'schema_file{index}'] = (schema_file.filename, schema_file.stream, schema_file.mimetype)
 
     response = requests.post(config.VALIDATOR_API_ENDPOINT + '/validate-sparql-endpoint', data=data, files=files,
                              params={'report_extension': report_extension})

--- a/validator/entrypoints/ui/forms.py
+++ b/validator/entrypoints/ui/forms.py
@@ -10,20 +10,18 @@
 
 """
 from flask_wtf import FlaskForm
-from flask_wtf.file import FileField, FileRequired, FileAllowed
-
-from wtforms import StringField, SubmitField, TextAreaField, RadioField
-from wtforms.validators import DataRequired, URL
+from flask_wtf.file import FileField, FileRequired
+from wtforms import StringField, SubmitField, TextAreaField, RadioField, MultipleFileField
+from wtforms.validators import DataRequired
 
 from validator.entrypoints.api.helpers import HTML_EXTENSION, TTL_EXTENSION, ZIP_EXTENSION
 
 
 class BaseValidateForm(FlaskForm):
-    report_extension = RadioField('Report Extension', choices=[(TTL_EXTENSION, 'Turtle report'), (HTML_EXTENSION, 'HTML report'),
-                                                               (ZIP_EXTENSION, 'Both reports')])
-    schema_file = FileField('Schema file*',
-                            validators=[FileRequired()])
-    submit = SubmitField('Validate')
+    report_extension = RadioField('Report Extension',
+                                  choices=[(TTL_EXTENSION, 'Turtle report'), (HTML_EXTENSION, 'HTML report'),
+                                           (ZIP_EXTENSION, 'Both reports')])
+    schema_files = MultipleFileField('Schema files*', description="Current maximum accepted files: 5.")
 
 
 class ValidateFromFileForm(BaseValidateForm):

--- a/validator/entrypoints/ui/templates/validate/file.html
+++ b/validator/entrypoints/ui/templates/validate/file.html
@@ -10,7 +10,12 @@
         {{ wtf.form_errors(form, hiddens="only") }}
 
         {{ wtf.form_field(form.data_file) }}
-        {{ wtf.form_field(form.schema_file) }}
+
+        <div class="form-group required">
+            <label class="control-label" for="schema_files">{{ form.schema_files.label }}</label>
+            <input id="schema_files" multiple="" name="schema_files" required="" type="file">
+            <p class="help-block">{{ form.schema_files.description }}</p>
+        </div>
 
         <label class="control-label" for="report_extension">Choose report type</label>
         {{ wtf.form_field(form.report_extension) }}

--- a/validator/entrypoints/ui/templates/validate/sparql_endpoint.html
+++ b/validator/entrypoints/ui/templates/validate/sparql_endpoint.html
@@ -9,7 +9,13 @@
         {{ wtf.form_errors(form, hiddens="only") }}
 
         {{ wtf.form_field(form.endpoint_url) }}
-        {{ wtf.form_field(form.schema_file) }}
+
+        <div class="form-group required">
+            <label class="control-label" for="schema_files">{{ form.schema_files.label }}</label>
+            <input id="schema_files" multiple="" name="schema_files" required="" type="file">
+            <p class="help-block">{{ form.schema_files.description }}</p>
+        </div>
+
         {{ wtf.form_field(form.graphs) }}
 
         <label class="control-label" for="report_extension">Choose report type</label>

--- a/validator/entrypoints/ui/views.py
+++ b/validator/entrypoints/ui/views.py
@@ -55,6 +55,7 @@ def validate_file():
 @app.route('/validate-sparql-endpoint', methods=['GET', 'POST'])
 def validate_sparql_endpoint():
     form = ValidateSPARQLEndpointForm()
+
     if form.validate_on_submit():
         response, status = api_validate_sparql_endpoint(
             report_extension=form.report_extension.data,

--- a/validator/entrypoints/ui/views.py
+++ b/validator/entrypoints/ui/views.py
@@ -35,7 +35,7 @@ def validate_file():
         response, status = api_validate_file(
             report_extension=form.report_extension.data,
             data_file=form.data_file.data,
-            schema_file=form.schema_file.data
+            schema_files=form.schema_files.data
         )
 
         if status != 200:
@@ -59,7 +59,7 @@ def validate_sparql_endpoint():
         response, status = api_validate_sparql_endpoint(
             report_extension=form.report_extension.data,
             sparql_endpoint_url=form.endpoint_url.data,
-            schema_file=form.schema_file.data,
+            schema_files=form.schema_files.data,
             graphs=form.graphs.data.split()
         )
 

--- a/validator/service_layer/handlers.py
+++ b/validator/service_layer/handlers.py
@@ -200,20 +200,20 @@ def create_report(location: str, html_report: str, ttl_report: str, extension: s
     return report_path, report_filename
 
 
-def build_report_from_file(location: str, data_file: str, schema_file: str, extension: str,
+def build_report_from_file(location: str, data_file: str, schema_files: list, extension: str,
                            file_name: str = 'file') -> tuple:
     html_report, ttl_report = run_file_validator(data_file=data_file,
-                                                 schemas=[schema_file],
+                                                 schemas=schema_files,
                                                  output=str(Path(location)) + '/')
 
     return create_report(location, html_report, ttl_report, extension, file_name)
 
 
-def build_report_from_sparql_endpoint(location: str, endpoint: str, graphs: list, schema_file: str, extension: str,
+def build_report_from_sparql_endpoint(location: str, endpoint: str, graphs: list, schema_files: list, extension: str,
                                       file_name: str = 'file') -> tuple:
     html_report, ttl_report = run_sparql_endpoint_validator(sparql_endpoint_url=endpoint,
                                                             graphs_uris=graphs,
-                                                            schemas=[schema_file],
+                                                            schemas=schema_files,
                                                             output=str(Path(location)) + '/')
 
     return create_report(location, html_report, ttl_report, extension, file_name)


### PR DESCRIPTION
## Considerations for current implementation:

- shacl file limit - 5 files. if more than 5 files will be uploaded on the UI (the ones after the 5th will be silently ignored)
- to select multiple files they have to be in the same directory